### PR TITLE
Fix verbiage for proper commit messages in contributing.md

### DIFF
--- a/contributing.md
+++ b/contributing.md
@@ -9,16 +9,16 @@ This document contains certain rules and guidelines that developers are expected
   > `<Verb in present tense> <Action>`
   
   :white_check_mark: __Examples of valid messages:__
-  * Added serialisers.py for users app
-  * Updated utils/validator.js file
-  * Changed functionality of authentication process
+  * Add serialisers.py for users app
+  * Update utils/validator.js file
+  * Change functionality of authentication process
   
   :x: __Examples of invalid messages:__
   * Idk why this is not working
   * Only ui bug fixes left
   * All changes done, ready for production :))
   
-* Before opening a PR, make sure you squash all your commits into one single commit using `it rebase` (squash). Instead of having 50 commits that describe 1 feature implementation, there must be one commit that describes everything that has been done so far. You can read up about it [here](https://www.internalpointers.com/post/squash-commits-into-one-git).
+* Before opening a PR, make sure you squash all your commits into one single commit using `git rebase` (squash). Instead of having 50 commits that describe 1 feature implementation, there must be one commit that describes everything that has been done so far. You can read up about it [here](https://www.internalpointers.com/post/squash-commits-into-one-git).
 > NOTE: While squashing your commits to write a new one, do not make use of `-m` flag. In this case, a vim editor window shall open. Write a title for the commit within 50-70 characters, leave a line and add an understandable description.
 
 ## 2. Issues


### PR DESCRIPTION

### Description
The contributing file says to use present tense, but the examples were all in past tense.

### Type of Change:
- Documentation

**Code/Quality Assurance Only**
- This change requires a documentation update (software upgrade on contributing file)


### How Has This Been Tested?
No tests required


### Checklist:
- [x] I have made corresponding changes to the documentation


**Code/Quality Assurance Only**
