### PR TITLE
Add validations for creating a task

### DIFF
--- a/Application/To-Do.xcodeproj/project.pbxproj
+++ b/Application/To-Do.xcodeproj/project.pbxproj
@@ -19,6 +19,7 @@
 		5BBE55CB2524623900090F87 /* TextviewBorder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BBE55CA2524623900090F87 /* TextviewBorder.swift */; };
 		603B4C66252647BD00579EC6 /* ResultsTableController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 603B4C65252647BD00579EC6 /* ResultsTableController.swift */; };
 		AB95E033252712C4008C4E48 /* TaskCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB95E032252712C4008C4E48 /* TaskCell.swift */; };
+		FF2303B42529183700B88831 /* Alert.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF2303B32529183700B88831 /* Alert.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -36,6 +37,7 @@
 		5BBE55CA2524623900090F87 /* TextviewBorder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextviewBorder.swift; sourceTree = "<group>"; };
 		603B4C65252647BD00579EC6 /* ResultsTableController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResultsTableController.swift; sourceTree = "<group>"; };
 		AB95E032252712C4008C4E48 /* TaskCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaskCell.swift; sourceTree = "<group>"; };
+		FF2303B32529183700B88831 /* Alert.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Alert.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -113,6 +115,7 @@
 				5BBE559D2523A42700090F87 /* AppDelegate.swift */,
 				5BBE559F2523A42700090F87 /* SceneDelegate.swift */,
 				5BBE55CA2524623900090F87 /* TextviewBorder.swift */,
+				FF2303B32529183700B88831 /* Alert.swift */,
 			);
 			path = Helpers;
 			sourceTree = "<group>";
@@ -196,6 +199,7 @@
 				5BBE55CB2524623900090F87 /* TextviewBorder.swift in Sources */,
 				603B4C66252647BD00579EC6 /* ResultsTableController.swift in Sources */,
 				5BBE55C925245DBF00090F87 /* TaskDetailsViewController.swift in Sources */,
+				FF2303B42529183700B88831 /* Alert.swift in Sources */,
 				AB95E033252712C4008C4E48 /* TaskCell.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Application/To-Do/Controller/TaskDetailsViewController.swift
+++ b/Application/To-Do/Controller/TaskDetailsViewController.swift
@@ -48,6 +48,7 @@ class TaskDetailsViewController: UIViewController{
     }
     
     @IBAction func saveTapped(_ sender: UIBarButtonItem) {
+        if !isValidTask() { return }
         guard let task = createTaskBody() else {
             self.navigationController?.popViewController(animated: true)
             return
@@ -58,6 +59,22 @@ class TaskDetailsViewController: UIViewController{
             self.delegate?.didTapSave(task: task)
         }
         self.navigationController?.popViewController(animated: true)
+    }
+
+    /// Function that determines if a task is valid or not. A valid task has both a title and due date.
+    /// Title: String taken from `taskTitleTextField`
+    /// endDate : String taken from `endDueDateTextField`
+    /// - Returns: A bool whether or not the task is valid.
+    func isValidTask() -> Bool {
+        if taskTitleTextField.text!.isEmpty {
+            Alert.showNoTaskTitle(on: self)
+            return false
+        }else if endDateTextField.text!.isEmpty {
+            Alert.showNoTaskDueDate(on: self)
+            return false
+        } else {
+            return true
+        }
     }
     
     // function that `Creates Task body`

--- a/Application/To-Do/Helpers/Alert.swift
+++ b/Application/To-Do/Helpers/Alert.swift
@@ -1,0 +1,38 @@
+//
+//  Alert.swift
+//  To-Do
+//
+//  Created by Mikaela Caron on 10/3/20.
+//  Copyright © 2020 Aaryan Kothari. All rights reserved.
+//
+
+import UIKit
+
+/// Defines static functions for various alerts that can be used throughout the app
+struct Alert {
+
+    /// Creates a UIAlertController and presents it on the specific view controller
+    /// - Parameters:
+    ///     - vc: The UIViewController where the alert is presented
+    ///     - title: The title of the UIAlertController
+    ///     - message: The message of the UIAlertController
+    private static func showBasicAlert(on vc: UIViewController, title: String, message: String) {
+        let alert = UIAlertController(title: title, message: message, preferredStyle: .alert)
+        alert.addAction(UIAlertAction(title: "OK", style: .default, handler: nil))
+        DispatchQueue.main.async { vc.present(alert, animated: true, completion: nil) }
+    }
+
+    /// Run `showBasicAlert` with a specified title and message related to not having a title for the task
+    /// - Parameters:
+    ///     - vc: UIViewController to present this alert
+    static func showNoTaskTitle(on vc: UIViewController) {
+        showBasicAlert(on: vc, title: "😧 Uh Oh", message: "Give your task a name!")
+    }
+
+    /// Run `showBasicAlert` with a specified title and message related to not having a due date for the task
+    /// - Parameters:
+    ///     - vc: UIViewController to present this alert
+    static func showNoTaskDueDate(on vc: UIViewController) {
+        showBasicAlert(on: vc, title: "🙁 Uh Oh", message: "Due date is empty")
+    }
+}


### PR DESCRIPTION

### Description
Add validations before creating a new task. Use a UIAlertController to notify the user that they need to add something before creating their task.

Fixes #36 

### Type of Change:
- Code
- User Interface

**Code/Quality Assurance Only**
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality pre-approved by mentors)


### How Has This Been Tested?
Click the + icon in the top right if either the taskTitleTextField or endDueDateTextField is empty, a UIAlertController will be presented. Once both have strings in them, the task can be added.


### Checklist:
- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials
- [x] I have commented my code or provided relevant documentation, particularly in hard-to-understand areas

**Code/Quality Assurance Only**
- [x] My changes generate no new warnings 
