### PR TITLE
Add empty fetch result state (#57)

### DIFF
--- a/Application/To-Do/Controller/ResultsTableController.swift
+++ b/Application/To-Do/Controller/ResultsTableController.swift
@@ -13,7 +13,13 @@ class ResultsTableController: UITableViewController {
     
     var todoList = [Task]()
     
+    
+    //MARK: UITableView DataSource
+    
     override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        
+        self.todoList.count == 0 ? self.showEmptyState() : self.hideEmptyState()
+        
         return todoList.count
     }
     
@@ -23,5 +29,21 @@ class ResultsTableController: UITableViewController {
         cell.textLabel?.text = task.title
         cell.detailTextLabel?.text = task.dueDate
         return cell
+    }
+    
+    //MARK : Fetch Result State Handling
+    
+    private func showEmptyState() {
+        
+        let emptyResultLabel = UILabel()
+        emptyResultLabel.translatesAutoresizingMaskIntoConstraints = false
+        emptyResultLabel.text = "No Search results!"
+        emptyResultLabel.textColor = .black
+        emptyResultLabel.textAlignment = .center
+        self.tableView.backgroundView = emptyResultLabel
+    }
+    
+    private func hideEmptyState() {
+        self.tableView.backgroundView = nil
     }
 }


### PR DESCRIPTION
### Description
A simple state for an empty search fetch result presented by a label as the tableView backgroundView.
It gets nilled when the searchResult.count is > 0.

Fixes #57

![Bildschirmfoto 2020-10-10 um 13 42 26](https://user-images.githubusercontent.com/55978783/95654357-c7cd7080-0aff-11eb-8c21-28470c71aae7.png)
![Bildschirmfoto 2020-10-10 um 13 42 52](https://user-images.githubusercontent.com/55978783/95654358-c9973400-0aff-11eb-8b90-ef4dae4df193.png)

### Type of Change:
- Code
- User Interface

**Code/Quality Assurance Only**
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality pre-approved by mentors)

### How Has This Been Tested?
Added Tasks to the ToDo List and search for a tasks which doesn't exists there. The backgroundView only gets displayed when self.todoList.count == 0 and gets nilled when > 0.

### Checklist:
**Delete irrelevant options.**

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials
- [x] I have commented my code or provided relevant documentation, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Any dependent changes have been merged 

**Code/Quality Assurance Only**
- [x] My changes generate no new warnings 
- [ ] My PR currently breaks something (fix or feature that would cause existing functionality to not work as expected)
