### PR TITLE
Delete task from HistoryTab using Trailing Swipe Action

### DIFF
--- a/Application/To-Do/Controller/TaskHistoryViewController.swift
+++ b/Application/To-Do/Controller/TaskHistoryViewController.swift
@@ -68,6 +68,34 @@ class TaskHistoryViewController: UIViewController {
             print("can't fetch data")
         }
     }
+    /// Deletes task from CoreData and removes from `completedList` and `historyTableView`
+    /// - Parameter indexPath: Which task to  delete
+    func deleteTask(indexPath: IndexPath){
+
+        let confirmation = UIAlertController(title: nil, message: "Delete this task?", preferredStyle: .actionSheet)
+        let deleteAction = UIAlertAction(title: "Yes", style: .destructive) { [weak self] (_) in
+            guard let self = self else { return }
+            self.historyTableView.beginUpdates()
+
+            let task = self.completedList.remove(at: indexPath.row)
+            self.historyTableView.deleteRows(at: [indexPath], with: .automatic)
+            self.moc.delete(task)
+            do {
+                try self.moc.save()
+            } catch {
+                self.completedList.insert(task, at: indexPath.row)
+                print(error.localizedDescription)
+            }
+            self.historyTableView.endUpdates()
+        }
+        let noAction = UIAlertAction(title: "No", style: .cancel) { (_) in
+            print("not going to delete")
+            return
+        }
+        confirmation.addAction(deleteAction)
+        confirmation.addAction(noAction)
+        present(confirmation, animated: true, completion: nil)
+    }
 }
 
 // MARK: - TableView DataSource and Delegate Methods
@@ -92,5 +120,11 @@ extension TaskHistoryViewController: UITableViewDelegate, UITableViewDataSource 
         cell.subtitle.text = task.dueDate
         cell.starImage.isHidden = true
         return cell
+    }
+
+    func tableView(_ tableView: UITableView, commit editingStyle: UITableViewCell.EditingStyle, forRowAt indexPath: IndexPath) {
+        if editingStyle == .delete {
+            deleteTask(indexPath: indexPath)
+        }
     }
 }


### PR DESCRIPTION
### Description
Delete task from the History tab using a trailing swipe action

Fixes #70 

### Type of Change:
- Code

**Code/Quality Assurance Only**
- New feature (non-breaking change which adds functionality pre-approved by mentors)



### How Has This Been Tested?
Perform a trailing swipe action on the history tab table view cell. Select Yes from the action sheet confirmation.


### Checklist:
- [x ] My PR follows the style guidelines of this project
- [x ] I have performed a self-review of my own code or materials
- [x ] I have commented my code or provided relevant documentation, particularly in hard-to-understand areas

**Code/Quality Assurance Only**
- [x ] My changes generate no new warnings 
