### PR TITLE
empty state fix when there is a completed task

### DIFF
--- a/Application/To-Do/Controller/ResultsTableController.swift
+++ b/Application/To-Do/Controller/ResultsTableController.swift
@@ -29,7 +29,7 @@ class ResultsTableController: UITableViewController {
     
     override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         
-       if todoList.count == 0 {
+        if todoList.isEmpty {
             self.tableView.backgroundView?.isHidden = false
             self.tableView.separatorStyle = .none
         } else {

--- a/Application/To-Do/Controller/TaskHistoryViewController.swift
+++ b/Application/To-Do/Controller/TaskHistoryViewController.swift
@@ -34,7 +34,9 @@ class TaskHistoryViewController: UIViewController {
 
     override func viewWillAppear(_ animated: Bool) {
         loadData()
-        setupEmptyState()
+        if completedList.isEmpty {
+            setupEmptyState()
+        }
     }
 
     // MARK: - Logic
@@ -74,7 +76,7 @@ class TaskHistoryViewController: UIViewController {
 extension TaskHistoryViewController: UITableViewDelegate, UITableViewDataSource {
     
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        if completedList.count == 0 {
+        if completedList.isEmpty {
              self.historyTableView.backgroundView?.isHidden = false
              self.historyTableView.separatorStyle = .none
          } else {

--- a/Application/To-Do/Controller/TodoViewController.swift
+++ b/Application/To-Do/Controller/TodoViewController.swift
@@ -189,7 +189,7 @@ class TodoViewController: UITableViewController {
     override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         self.sortButton.isEnabled = self.todoList.count > 0
         
-        if todoList.count == 0 {
+        if todoList.isEmpty {
             tableView.separatorStyle = .none
             tableView.backgroundView?.isHidden = false
         } else {

--- a/Application/To-DoTests/TaskTests.swift
+++ b/Application/To-DoTests/TaskTests.swift
@@ -84,7 +84,7 @@ class TaskTests: XCTestCase {
     }
 
     func testCreatTask() {
-        let task = createTask(title: "Task Titile", dueDateTimeStamp: Date().timeIntervalSince1970)
+        let task = createTask(title: "Task Title", dueDateTimeStamp: Date().timeIntervalSince1970)
         XCTAssertNotNil(task)
     }
     


### PR DESCRIPTION
### Description
Empty state shouldn't be shown on history tab when there is at least one completed task.

Fixes [#80]

### Type of Change:
**Delete irrelevant options.**

- Code
- Quality Assurance

**Code/Quality Assurance Only**
- Bug fix (non-breaking change which fixes an issue)



### How Has This Been Tested?
Steps:
- Add a new task from tasks tab.
- Complete the task using right swipe.
- History tab shouldn't show empty state

### Checklist:
**Delete irrelevant options.**

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials
- [x] I have commented my code or provided relevant documentation, particularly in hard-to-understand areas

**Code/Quality Assurance Only**
- [x] My changes generate no new warnings 
