### PR TITLE
Adds haptics to TasksDetails and TodoViewController

### DIFF
--- a/Application/To-Do/Controller/TaskDetailsViewController.swift
+++ b/Application/To-Do/Controller/TaskDetailsViewController.swift
@@ -35,6 +35,8 @@ class TaskDetailsViewController: UIViewController{
     
     var cameraHelper = CameraHelper()
     
+    var hapticGenerator: UINotificationFeedbackGenerator? = nil
+
     override func viewDidLoad() {
         super.viewDidLoad()
         isUpdate = (task != nil)
@@ -64,17 +66,28 @@ class TaskDetailsViewController: UIViewController{
     }
     
     @IBAction func saveTapped(_ sender: UIBarButtonItem) {
-        guard isValidTask() else { return }
+        hapticGenerator = UINotificationFeedbackGenerator()
+        hapticGenerator?.prepare()
+        
+        guard isValidTask() else {
+            hapticGenerator?.notificationOccurred(.warning)
+            return
+        }
         guard let task = createTaskBody() else {
             self.navigationController?.popViewController(animated: true)
             return
         }
+        
+        hapticGenerator?.notificationOccurred(.success)
+
         if isUpdate {
             self.delegate?.didTapUpdate(task: task)
         } else {
             self.delegate?.didTapSave(task: task)
         }
         self.navigationController?.popViewController(animated: true)
+        
+        hapticGenerator = nil
     }
     
     /// Function that determines if a task is valid or not. A valid task has both a title and due date.

--- a/Application/To-Do/Controller/TodoViewController.swift
+++ b/Application/To-Do/Controller/TodoViewController.swift
@@ -46,6 +46,7 @@ class TodoViewController: UITableViewController {
     /// default sort is `Alphabetical ascending`
     var currentSelectedSortType: SortTypesAvailable = .sortByNameAsc
     
+    var hapticNotificationGenerator: UINotificationFeedbackGenerator? = nil
     
     //MARK: -------- View lifecycle methods --------
     
@@ -112,15 +113,21 @@ class TodoViewController: UITableViewController {
     /// function called when `Delete Task` tapped
     /// - Parameter index: Which task to  delete
     func deleteTask(at index : Int){
+        hapticNotificationGenerator = UINotificationFeedbackGenerator()
+        hapticNotificationGenerator?.prepare()
+        
         let element = todoList.remove(at: index) /// removes task at index
         moc.delete(element) /// deleting the object from core data
         do {
             try moc.save()
+            hapticNotificationGenerator?.notificationOccurred(.success)
         } catch {
             todoList.insert(element, at: index)
             print(error.localizedDescription)
+            hapticNotificationGenerator?.notificationOccurred(.error)
         }
         tableView.reloadData() /// Reload tableview with remaining data
+        hapticNotificationGenerator = nil
     }
     
     /// Mark a task as complete and remove from the `tableView`
@@ -135,12 +142,18 @@ class TodoViewController: UITableViewController {
     /// Update task
     /// function called whenever updating a task is required
     func updateTask(){
+        hapticNotificationGenerator = UINotificationFeedbackGenerator()
+        hapticNotificationGenerator?.prepare()
+        
         do {
             try moc.save()
+            hapticNotificationGenerator?.notificationOccurred(.success)
         } catch {
             print(error.localizedDescription)
+            hapticNotificationGenerator?.notificationOccurred(.error)
         }
         loadData()
+        hapticNotificationGenerator = nil
     }
     
     override func prepare(for segue: UIStoryboardSegue, sender: Any?) {


### PR DESCRIPTION
### Description
I looked up Reminders (from Apple) and some other apps to see how they use haptics. Create or addition buttons usually don't have any feedback, some notifications do. 

With that in mind, I added UINotificationFeedbackGenerator to Todo and TaskDetails view controllers on the following actions:
- success or failure when creating/updating a task
- success when starring a task
- success or failure when deleting a task

| Update Error | Add Success | Star and Delete |
| ---- | ---- | ---- |
| <img width="559" alt="update_error" src="https://user-images.githubusercontent.com/8649944/96884964-7ce51e80-1458-11eb-84f5-f6759b19d7a9.png"> | <img width="559" alt="add_success" src="https://user-images.githubusercontent.com/8649944/96885013-8cfcfe00-1458-11eb-921b-f9a150862f73.png"> | <img width="559" alt="star_delete" src="https://user-images.githubusercontent.com/8649944/96885058-99815680-1458-11eb-8dd8-9d2cdb2cbc79.png"> |


Fixes #46 [https://github.com/IEEE-VIT/ToDo-iOS/issues/46]

### Type of Change:

- Code
- User Interface

**Code/Quality Assurance Only**
- New feature (non-breaking change which adds functionality pre-approved by mentors)



### How Has This Been Tested?
The tests were run on a physical device. iPhone XS iOS 14.0.1


### Checklist:

- [x] My PR follows the style guidelines of this project
- [ ] I have performed a self-review of my own code or materials
- [x] I have commented my code or provided relevant documentation, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Any dependent changes have been merged 

**Code/Quality Assurance Only**
- [x] My changes generate no new warnings 
- [ ] My PR currently breaks something (fix or feature that would cause existing functionality to not work as expected)
