### PR TITLE
Users can now see taskDetailsVC with completed tasks

### DIFF
--- a/Application/To-Do/Controller/TaskHistoryViewController.swift
+++ b/Application/To-Do/Controller/TaskHistoryViewController.swift
@@ -10,7 +10,7 @@ import UIKit
 import CoreData
 
 class TaskHistoryViewController: UIViewController {
-
+    
     // MARK: - IBOutlets
     @IBOutlet var historyTableView: UITableView!
 
@@ -19,7 +19,7 @@ class TaskHistoryViewController: UIViewController {
 
     /// CoreData managed object
     var moc: NSManagedObjectContext!
-
+    
     /// Default fetch request for tasks
     lazy var defaultFetchRequest: NSFetchRequest<Task> = {
         let fetchRequest : NSFetchRequest<Task> = Task.fetchRequest()
@@ -98,6 +98,23 @@ class TaskHistoryViewController: UIViewController {
         confirmation.addAction(noAction)
         present(confirmation, animated: true, completion: nil)
     }
+    
+    // I wasn't sure if you want the user to be able to update completed tasks so I set isUserInteractionEnabled to false for all subviews of taskDetailVC
+    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
+        if let taskDetailVC = segue.destination as? TaskDetailsViewController {
+            // Hide the tab bar when new controller is pushed onto the screen
+            taskDetailVC.hidesBottomBarWhenPushed = true
+//            taskDetailVC.delegate = self
+            taskDetailVC.task = sender as? Task
+            taskDetailVC.view.subviews.forEach {
+                $0.isUserInteractionEnabled = false
+            }
+            if let button = taskDetailVC.navigationItem.rightBarButtonItem {
+                button.isEnabled = false
+                button.tintColor = .clear
+            }
+        }
+    }
 }
 
 // MARK: - TableView DataSource and Delegate Methods
@@ -128,5 +145,11 @@ extension TaskHistoryViewController: UITableViewDelegate, UITableViewDataSource 
         if editingStyle == .delete {
             deleteTask(indexPath: indexPath)
         }
+    }
+    
+    // pushes taskDetailsVC with completed task details
+    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        let task = completedList[indexPath.row]
+        performSegue(withIdentifier: Constants.Segue.taskToTaskDetail, sender: task)
     }
 }

--- a/Application/To-Do/View/Base.lproj/Main.storyboard
+++ b/Application/To-Do/View/Base.lproj/Main.storyboard
@@ -1,9 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="15705" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="Ays-iC-G6a">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="Ays-iC-G6a">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15706"/>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17703"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="collection view cell content view" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -36,7 +38,7 @@
                         <subviews>
                             <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="uSS-BT-6iJ">
                                 <rect key="frame" x="0.0" y="88" width="414" height="808"/>
-                                <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <prototypes>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" accessoryType="disclosureIndicator" indentationWidth="10" reuseIdentifier="todocell" rowHeight="75" id="ufA-wl-Cek" customClass="TaskCell" customModule="To_Do" customModuleProvider="target">
                                         <rect key="frame" x="0.0" y="28" width="414" height="75"/>
@@ -95,18 +97,19 @@
                                 </connections>
                             </tableView>
                         </subviews>
-                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <viewLayoutGuide key="safeArea" id="DlE-g9-AnT"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
                             <constraint firstItem="uSS-BT-6iJ" firstAttribute="top" secondItem="DlE-g9-AnT" secondAttribute="top" id="ETj-QP-wgz"/>
                             <constraint firstAttribute="bottom" secondItem="uSS-BT-6iJ" secondAttribute="bottom" id="N8q-Mz-inr"/>
                             <constraint firstItem="uSS-BT-6iJ" firstAttribute="leading" secondItem="DlE-g9-AnT" secondAttribute="leading" id="Vta-P4-woK"/>
                             <constraint firstItem="DlE-g9-AnT" firstAttribute="trailing" secondItem="uSS-BT-6iJ" secondAttribute="trailing" id="WXB-Tn-2Pt"/>
                         </constraints>
-                        <viewLayoutGuide key="safeArea" id="DlE-g9-AnT"/>
                     </view>
                     <navigationItem key="navigationItem" title="History" id="nyZ-60-KSb"/>
                     <connections>
                         <outlet property="historyTableView" destination="uSS-BT-6iJ" id="08N-xd-gfB"/>
+                        <segue destination="4AD-BL-kUr" kind="show" identifier="gototask" id="Dgn-eg-4tD"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="ZBV-mI-cUb" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
@@ -168,8 +171,8 @@
                             </textField>
                             <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" text="Enter your subtask here" translatesAutoresizingMaskIntoConstraints="NO" id="SOr-LH-5cU">
                                 <rect key="frame" x="20" y="253" width="374" height="128"/>
-                                <color key="backgroundColor" systemColor="secondarySystemGroupedBackgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                <color key="textColor" systemColor="labelColor" cocoaTouchSystemColor="darkTextColor"/>
+                                <color key="backgroundColor" systemColor="secondarySystemGroupedBackgroundColor"/>
+                                <color key="textColor" systemColor="labelColor"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                 <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
                                 <connections>
@@ -229,7 +232,7 @@
                                     <outlet property="delegate" destination="4AD-BL-kUr" id="psV-6i-u9l"/>
                                 </connections>
                             </collectionView>
-                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="94v-so-iyY">
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="94v-so-iyY">
                                 <rect key="frame" x="284" y="514" width="100" height="30"/>
                                 <constraints>
                                     <constraint firstAttribute="width" constant="100" id="eLV-gY-37Y"/>
@@ -240,7 +243,8 @@
                                 </connections>
                             </button>
                         </subviews>
-                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <viewLayoutGuide key="safeArea" id="7AC-Jy-fo4"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
                             <constraint firstItem="7AC-Jy-fo4" firstAttribute="trailing" secondItem="94v-so-iyY" secondAttribute="trailing" constant="30" id="0lh-ae-dVL"/>
                             <constraint firstItem="SOr-LH-5cU" firstAttribute="top" secondItem="ngX-g4-4zR" secondAttribute="bottom" constant="8" id="1Cj-bc-dHP"/>
@@ -271,7 +275,6 @@
                             <constraint firstItem="94v-so-iyY" firstAttribute="top" secondItem="0O5-ye-SqQ" secondAttribute="bottom" constant="30" id="tV3-Wf-90U"/>
                             <constraint firstItem="aD0-wr-4cR" firstAttribute="leading" secondItem="7AC-Jy-fo4" secondAttribute="leading" constant="20" id="yJH-LP-vqT"/>
                         </constraints>
-                        <viewLayoutGuide key="safeArea" id="7AC-Jy-fo4"/>
                     </view>
                     <navigationItem key="navigationItem" largeTitleDisplayMode="never" id="4zH-lp-Fau">
                         <barButtonItem key="rightBarButtonItem" title="Save" style="plain" id="Zfe-d1-cWG">
@@ -323,7 +326,7 @@
                                                         </constraints>
                                                     </imageView>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Never forget any task again." textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="j8m-fw-ILx">
-                                                        <rect key="frame" x="76" y="0.0" width="224" height="20.5"/>
+                                                        <rect key="frame" x="76" y="0.0" width="222.5" height="20.5"/>
                                                         <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="17"/>
                                                         <nil key="textColor"/>
                                                         <nil key="highlightedColor"/>
@@ -335,7 +338,7 @@
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                 </subviews>
-                                                <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                                 <constraints>
                                                     <constraint firstAttribute="trailing" secondItem="EpX-Oj-A98" secondAttribute="trailing" id="274-Pb-fOJ"/>
                                                     <constraint firstItem="wFL-11-ceo" firstAttribute="top" secondItem="UJY-1L-u31" secondAttribute="top" id="Obs-4b-bPp"/>
@@ -359,7 +362,7 @@
                                                         </constraints>
                                                     </imageView>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Sort your tasks." textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="fjp-3s-m6T">
-                                                        <rect key="frame" x="76" y="0.0" width="126.5" height="20.5"/>
+                                                        <rect key="frame" x="76" y="0.0" width="126" height="20.5"/>
                                                         <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="17"/>
                                                         <nil key="textColor"/>
                                                         <nil key="highlightedColor"/>
@@ -371,7 +374,7 @@
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                 </subviews>
-                                                <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                                 <constraints>
                                                     <constraint firstItem="TTy-ae-Caa" firstAttribute="top" secondItem="GpJ-tY-hTi" secondAttribute="top" id="059-58-ruI"/>
                                                     <constraint firstAttribute="bottom" secondItem="gOW-5m-m79" secondAttribute="bottom" id="5tD-jh-zC6"/>
@@ -395,7 +398,7 @@
                                                         </constraints>
                                                     </imageView>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Set priorities for your tasks." textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="odz-9X-63U">
-                                                        <rect key="frame" x="76" y="0.0" width="221" height="20.5"/>
+                                                        <rect key="frame" x="76" y="0.0" width="220" height="20.5"/>
                                                         <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="17"/>
                                                         <nil key="textColor"/>
                                                         <nil key="highlightedColor"/>
@@ -409,7 +412,7 @@
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                 </subviews>
-                                                <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                                 <constraints>
                                                     <constraint firstItem="kob-6N-gf7" firstAttribute="leading" secondItem="odz-9X-63U" secondAttribute="leading" id="4ZF-Ok-lsk"/>
                                                     <constraint firstAttribute="bottom" secondItem="kob-6N-gf7" secondAttribute="bottom" id="4ea-bs-7FI"/>
@@ -426,14 +429,14 @@
                                                 <rect key="frame" x="16" y="362.5" width="382" height="58.5"/>
                                                 <subviews>
                                                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="timer" catalog="system" translatesAutoresizingMaskIntoConstraints="NO" id="Xez-SX-9w2">
-                                                        <rect key="frame" x="0.0" y="0.5" width="60" height="59"/>
+                                                        <rect key="frame" x="0.0" y="1" width="60" height="59"/>
                                                         <constraints>
                                                             <constraint firstAttribute="width" constant="60" id="Qkn-N0-Sr7"/>
                                                             <constraint firstAttribute="height" constant="60" id="dXA-t5-eb3"/>
                                                         </constraints>
                                                     </imageView>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Task History" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Wb0-kW-e6i">
-                                                        <rect key="frame" x="76" y="0.0" width="99.5" height="20.5"/>
+                                                        <rect key="frame" x="76" y="0.0" width="99" height="20.5"/>
                                                         <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="17"/>
                                                         <nil key="textColor"/>
                                                         <nil key="highlightedColor"/>
@@ -447,7 +450,7 @@
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                 </subviews>
-                                                <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                                 <constraints>
                                                     <constraint firstItem="Wb0-kW-e6i" firstAttribute="top" secondItem="H25-Aj-SI2" secondAttribute="top" id="0WT-Ej-9JQ"/>
                                                     <constraint firstAttribute="bottom" secondItem="hUt-3Y-bv9" secondAttribute="bottom" id="A2b-Jp-P7i"/>
@@ -460,9 +463,9 @@
                                                     <constraint firstItem="Wb0-kW-e6i" firstAttribute="leading" secondItem="Xez-SX-9w2" secondAttribute="trailing" constant="16" id="hL8-wl-wJ2"/>
                                                 </constraints>
                                             </view>
-                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="uHe-DW-zV4">
+                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="uHe-DW-zV4">
                                                 <rect key="frame" x="16" y="738" width="382" height="48"/>
-                                                <color key="backgroundColor" systemColor="systemBlueColor" red="0.0" green="0.47843137250000001" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                <color key="backgroundColor" systemColor="systemBlueColor"/>
                                                 <constraints>
                                                     <constraint firstAttribute="height" constant="48" id="7Mc-z5-TV3"/>
                                                 </constraints>
@@ -474,7 +477,7 @@
                                                 </connections>
                                             </button>
                                         </subviews>
-                                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                         <constraints>
                                             <constraint firstItem="3TG-cX-Xtw" firstAttribute="top" secondItem="GpJ-tY-hTi" secondAttribute="bottom" constant="32" id="4e9-D3-hxc"/>
                                             <constraint firstItem="uHe-DW-zV4" firstAttribute="trailing" secondItem="3TG-cX-Xtw" secondAttribute="trailing" id="6qR-pN-pnf"/>
@@ -508,14 +511,14 @@
                                 <viewLayoutGuide key="frameLayoutGuide" id="XTf-gy-7jB"/>
                             </scrollView>
                         </subviews>
-                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <viewLayoutGuide key="safeArea" id="0QU-mh-IJ2"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
                             <constraint firstItem="0QU-mh-IJ2" firstAttribute="bottom" secondItem="EH6-YJ-DJZ" secondAttribute="bottom" id="5VZ-Cy-xYx"/>
                             <constraint firstItem="EH6-YJ-DJZ" firstAttribute="leading" secondItem="0QU-mh-IJ2" secondAttribute="leading" id="Y0j-vL-eEJ"/>
                             <constraint firstItem="0QU-mh-IJ2" firstAttribute="top" secondItem="EH6-YJ-DJZ" secondAttribute="top" id="lc0-ni-rxu"/>
                             <constraint firstItem="0QU-mh-IJ2" firstAttribute="trailing" secondItem="EH6-YJ-DJZ" secondAttribute="trailing" id="zGN-6d-oPx"/>
                         </constraints>
-                        <viewLayoutGuide key="safeArea" id="0QU-mh-IJ2"/>
                     </view>
                     <connections>
                         <outlet property="nextButton" destination="uHe-DW-zV4" id="wAQ-Gk-9Qo"/>
@@ -532,7 +535,7 @@
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" id="LGs-Rx-YcS">
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <prototypes>
                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" accessoryType="disclosureIndicator" indentationWidth="10" reuseIdentifier="todocell" rowHeight="75" id="wkZ-0H-4Ms" customClass="TaskCell" customModule="To_Do" customModuleProvider="target">
                                 <rect key="frame" x="0.0" y="28" width="414" height="75"/>
@@ -620,7 +623,7 @@
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" id="Dfw-Dl-XqY">
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <prototypes>
                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" accessoryType="disclosureIndicator" indentationWidth="10" reuseIdentifier="todocell" textLabel="2Vz-e5-Se0" detailTextLabel="APq-gh-o8O" rowHeight="75" style="IBUITableViewCellStyleSubtitle" id="DKs-Fh-LeQ">
                                 <rect key="frame" x="0.0" y="28" width="414" height="75"/>
@@ -630,7 +633,7 @@
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Title" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="2Vz-e5-Se0">
-                                            <rect key="frame" x="20" y="17" width="33.5" height="20.5"/>
+                                            <rect key="frame" x="20" y="17" width="33" height="20.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                             <nil key="textColor"/>
@@ -677,12 +680,27 @@
             <point key="canvasLocation" x="-1697.1014492753625" y="825"/>
         </scene>
     </scenes>
+    <inferredMetricsTieBreakers>
+        <segue reference="zpk-Xa-XIl"/>
+    </inferredMetricsTieBreakers>
     <resources>
-        <image name="arrow.up.arrow.down" catalog="system" width="64" height="48"/>
-        <image name="folder" catalog="system" width="64" height="46"/>
-        <image name="pencil" catalog="system" width="64" height="56"/>
-        <image name="star.circle" catalog="system" width="64" height="60"/>
-        <image name="timer" catalog="system" width="64" height="60"/>
-        <image name="tray" catalog="system" width="64" height="44"/>
+        <image name="arrow.up.arrow.down" catalog="system" width="128" height="98"/>
+        <image name="folder" catalog="system" width="128" height="97"/>
+        <image name="pencil" catalog="system" width="128" height="113"/>
+        <image name="star.circle" catalog="system" width="128" height="121"/>
+        <image name="timer" catalog="system" width="128" height="121"/>
+        <image name="tray" catalog="system" width="128" height="88"/>
+        <systemColor name="labelColor">
+            <color white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+        <systemColor name="secondarySystemGroupedBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+        <systemColor name="systemBlueColor">
+            <color red="0.0" green="0.47843137254901963" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </systemColor>
     </resources>
 </document>


### PR DESCRIPTION
### Description
The cells in TaskHistoryVC didn't take users to TaskDetailsVC when tapped

Fixes # [90]

### Type of Change:
- In TaskHistoryVC, I added `override func prepare(for segue: , sender: )` to populate the views in TaskDetailsVC.
- I also added the didSelectRowAt function for tableview delegate that performs the segue.
- Inside MainStoryboard I made a segue from TaskHistoryVC to TaskDetailsVC using the identifier `Constants.Segue.taskToTaskDetail`
- I wasn't sure if you wanted users to be able to update completed tasks, so I set isUserInteractionEnabled to false for all subviews of TaskDetailsVC if user is looking at a completed task

### How Has This Been Tested?
Tested using the iPhone 11 pro simulator

### Checklist:
- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-review of my own code or materials
- [x] I have commented my code or provided relevant documentation, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged 

**Code/Quality Assurance Only**
- [x] My changes generate no new warnings 
- [  ] My PR currently breaks something (fix or feature that would cause existing functionality to not work as expected)
